### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,9 @@ jobs:
       - name: Build app
         working-directory: app
         run: npm run build
+
+      - name: Deploy app
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          folder: app/build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cofre
 
+[![app status](https://img.shields.io/website?label=app&url=https%3A%2F%2Fthreeal.github.io%2Fcofre)](https://threeal.github.io/cofre)
+
 A money manager, budget, and expenses app.
 
 ## Components

--- a/app/README.md
+++ b/app/README.md
@@ -1,5 +1,7 @@
 # Cofre App
 
+[![app status](https://img.shields.io/website?label=app&url=https%3A%2F%2Fthreeal.github.io%2Fcofre)](https://threeal.github.io/cofre)
+
 A web application for [Cofre](https://github.com/threeal/cofre).
 
 ## License

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "A web application for Cofre",
+  "homepage": "/cofre",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
Add a step in the `build-app` job of `build.yml` workflow to deploy [Cofre App](https://github.com/threeal/cofre/tree/main/app) to [GitHub Pages](https://pages.github.com/) using [Deploy to GitHub Pages](https://github.com/marketplace/actions/deploy-to-github-pages). Closes #4.