### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Cofre
 
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/cofre/build.yml?branch=main)](https://github.com/threeal/cofre/actions/workflows/build.yml)
-[![app status](https://img.shields.io/website?label=app&url=https%3A%2F%2Fthreeal.github.io%2Fcofre)](https://threeal.github.io/cofre)
-
 A money manager, budget, and expenses app.
 
 ## Components

--- a/app/README.md
+++ b/app/README.md
@@ -1,8 +1,5 @@
 # Cofre App
 
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/cofre/build.yml?branch=main)](https://github.com/threeal/cofre/actions/workflows/build.yml)
-[![app status](https://img.shields.io/website?label=app&url=https%3A%2F%2Fthreeal.github.io%2Fcofre)](https://threeal.github.io/cofre)
-
 A web application for [Cofre](https://github.com/threeal/cofre).
 
 ## License


### PR DESCRIPTION
This pull request resolves #481 by simply removing badges from the `README.md` files.