### PR TITLE
Fix Incorrect Build App Directory in Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload App
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          path: app/build
+          path: app/dist
 
       - name: Deploy App
         id: deploy-app


### PR DESCRIPTION
This pull request resolves #486 by fixing the incorrect build app directory that will be uploaded in the Deploy workflow.