### PR TITLE
Remove Glob Pattern for Filtering Lefthook Jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -19,4 +19,4 @@ pre-commit:
 
     - name: check diff
       root: app
-      run: git diff --exit-code {staged_files}
+      run: git diff --exit-code app/pnpm-lock.yaml {staged_files}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -4,20 +4,10 @@ pre-commit:
     - name: install dependencies
       root: app
       run: pnpm install
-      glob:
-        - .npmrc
-        - package.json
-        - pnpm-lock.yaml
-        - pnpm-workspace.yaml
 
     - name: check types
       root: app
       run: pnpm tsc
-      glob:
-        - "*.{ts,tsx}"
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
 
     - name: fix formatting
       root: app

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -11,11 +11,11 @@ pre-commit:
 
     - name: fix formatting
       root: app
-      run: pnpm prettier --write --ignore-unknown {staged_files}
+      run: pnpm prettier --write .
 
     - name: fix lint
       root: app
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+      run: pnpm eslint --fix
 
     - name: check diff
       root: app


### PR DESCRIPTION
This pull request resolves #526 by removing the glob pattern used to filter Lefthook jobs. It also modifies jobs to process all files and adds the `pnpm-lock.yaml` file to the list of files checked for changes.