### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/app/.prettierrc.json
+++ b/app/.prettierrc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["prettier-plugin-css-order"]
+  "plugins": ["prettier-plugin-css-order", "prettier-plugin-organize-imports"]
 }

--- a/app/eslint.config.ts
+++ b/app/eslint.config.ts
@@ -1,6 +1,6 @@
 import js from "@eslint/js";
-import { globalIgnores } from "eslint/config";
 import reactPlugin from "eslint-plugin-react";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "playwright": "^1.54.1",
     "prettier": "^3.5.3",
     "prettier-plugin-css-order": "^2.1.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^6.3.5",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier-plugin-css-order:
         specifier: ^2.1.2
         version: 2.1.2(postcss@8.5.4)(prettier@3.5.3)
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.5.3)(typescript@5.8.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -1622,6 +1625,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       prettier: 3.x
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -3727,6 +3740,11 @@ snapshots:
       prettier: 3.5.3
     transitivePeerDependencies:
       - postcss
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.5.3)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.5.3
+      typescript: 5.8.3
 
   prettier@3.5.3: {}
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 let base: string | undefined;
 if (process.env.GITHUB_REPOSITORY) {


### PR DESCRIPTION
This pull request resolves #529 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.