### PR TITLE
Fix Lefthook Check Diff Path

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -18,5 +18,4 @@ pre-commit:
       run: pnpm eslint --fix
 
     - name: check diff
-      root: app
       run: git diff --exit-code app/pnpm-lock.yaml {staged_files}


### PR DESCRIPTION
This pull request fixes #531 by removing `root` configuration in the `check diff` step of the Lefthook configuration.