### PR TITLE
Bump Node.js to Version 24.11.1

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.11.0
+use-node-version=24.11.1


### PR DESCRIPTION
This pull request bumps the Node.js version specified in the `.npmrc` file to version [24.11.1](https://github.com/nodejs/node/releases/tag/v24.11.1).