### PR TITLE
Bump Node.js to version 24.16.0

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.14.1
+use-node-version=24.16.0


### PR DESCRIPTION
This pull request updates the Node.js version specified in the `.npmrc` file to [24.16.0](https://github.com/nodejs/node/releases/tag/v24.16.0).