### PR TITLE
Bump pnpm to version 10.34.4

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,5 +34,5 @@
     "vitest": "^4.0.15",
     "vitest-browser-react": "^1.0.0"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@10.34.4"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [10.34.4](https://github.com/pnpm/pnpm/releases/tag/v10.34.4).