### PR TITLE
Bump Node to version 24.17.0

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.14.1
+use-node-version=24.17.0


### PR DESCRIPTION
This pull request bumps Node.js to version [24.17.0](https://github.com/nodejs/node/releases/tag/v24.17.0).