### PR TITLE
Remove `packages` option from `pnpm-workspace.yaml`

### DIFF
--- a/app/pnpm-workspace.yaml
+++ b/app/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-packages:
-  - .
 allowBuilds:
   esbuild: true
   lefthook: true


### PR DESCRIPTION
This pull request resolves #654 by removing the `packages` option from `pnpm-workspace.yaml`, simplifying the workspace configuration.